### PR TITLE
User can see a list of saved trips

### DIFF
--- a/trips/schema.py
+++ b/trips/schema.py
@@ -1,4 +1,5 @@
 import graphene
+from graphene import ObjectType
 
 from graphene_django.types import DjangoObjectType
 from trips.models import User, Trip, Destination, TripDestination, Date
@@ -23,8 +24,10 @@ class DateType(DjangoObjectType):
     class Meta:
         model = Date
 
-class Query(object):
-    all_trips = graphene.List(TripType)
+class Query(ObjectType):
+    all_trips = graphene.List(TripType, user_api_key=graphene.String(required=True))
 
     def resolve_all_trips(self, info, **kwargs):
-        return Trip.objects.all()
+        api_key = kwargs.get('user_api_key')
+        user = User.objects.get(api_key = api_key)
+        return Trip.objects.filter(user_id = user.id)

--- a/trips/tests.py
+++ b/trips/tests.py
@@ -1,3 +1,87 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from graphene_django.utils.testing import GraphQLTestCase
+from globe_trotter.schema import schema
+from trips.models import Trip, User
+
+class TripsTestCase(GraphQLTestCase):
+    GRAPHQL_SCHEMA = schema
+
+    def setUp(self):
+        self.maxDiff = None
+
+        User.objects.create(
+            email = 'john@gmail.com',
+            name = 'John',
+            api_key = '1234'
+        )
+
+        User.objects.create(
+            email = 'zac@gmail.com',
+            name = 'Zac',
+            api_key = '4567'
+        )
+
+        Trip.objects.create(
+            name = 'Spring Break',
+            origin = 'Denver, CO, USA',
+            origin_abbrev = 'DEN',
+            origin_lat = '39.7392',
+            origin_long = '104.9903',
+            start_date = '2020-03-16',
+            end_date = '2020-03-23',
+            user = User.objects.first()
+        )
+
+    def test_all_trips(self):
+        response = self.query(
+            '''
+            query {
+                allTrips(userApiKey: "1234") {
+                    id
+                    name
+                    origin
+                    originAbbrev
+                    originLat
+                    originLong
+                    startDate
+                    endDate
+                    user {
+                        id
+                        name
+                        email
+                    }
+                }
+            }
+            ''',
+            op_name='Trip'
+        )
+
+        expected = {
+            "data": {
+                "allTrips": [
+                    {
+                        "id": "1",
+                        "name": "Spring Break",
+                        "origin": "Denver, CO, USA",
+                        "originAbbrev": "DEN",
+                        "originLat": "39.7392",
+                        "originLong": "104.9903",
+                        "startDate": "2020-03-16",
+                        "endDate": "2020-03-23",
+                        "user": {
+                            "id": "1",
+                            "name": "John",
+                            "email": "john@gmail.com"
+                        }
+                    }
+                ]
+            }
+        }
+
+        content = json.loads(response.content)
+
+        self.assertResponseNoErrors(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, expected)


### PR DESCRIPTION
### What's this PR do?
- Add GraphQL endpoint for allTrips
- Add happy path test for endpoint
- Authenticate user before displaying list of trips

### Where should the reviewer start?
- In trips/schema.py to check out the GraphQL schema
- In trips/tests.py to see the expected request/response for the endpoint

### How should this be manually tested?
- Using localhost

### What are the relevant tickets?
- Issue #1: User can see a list of saved trips

### Questions:
- Are there further configurations for GraphQL
- We'll need to add destinations to fulfill frontend needs