### PR TITLE
User can create a destination for a trip

### DIFF
--- a/trips/schema.py
+++ b/trips/schema.py
@@ -46,6 +46,33 @@ class CreateTrip(Mutation):
 
         return CreateTrip(trip=trip)
 
+class CreateDestination(Mutation):
+    destination = graphene.Field(DestinationType)
+
+    class Arguments:
+        user_api_key = graphene.String(required=True)
+        trip_id = graphene.ID(required=True)
+        location = graphene.String(required= True)
+        start_date = graphene.types.datetime.Date(required=True)
+        end_date = graphene.types.datetime.Date(required=True)
+
+    def mutate(self, info, user_api_key, trip_id, location, start_date, end_date):
+        user = User.objects.get(api_key = user_api_key)
+        trip = Trip.objects.filter(user_id=user.id).get(id=trip_id)
+        destination = Destination()
+        response = get_coordinates(location)
+        destination.location = response[0]['formatted_address']
+        destination.lat = response[0]['geometry']['location']['lat']
+        destination.long = response[0]['geometry']['location']['lng']
+        destination.abbrev = get_airport_code(destination.location)
+        destination.save()
+
+        trip_destination = TripDestination(start_date=start_date, end_date=end_date, trip=trip, destination=destination)
+        trip_destination.save()
+
+        return CreateDestination(destination=destination)
+
+
 
 class Query(ObjectType):
     all_trips = graphene.List(TripType, user_api_key=graphene.String(required=True))
@@ -57,3 +84,4 @@ class Query(ObjectType):
 
 class Mutation(ObjectType):
     create_trip = CreateTrip.Field()
+    create_destination = CreateDestination.Field()

--- a/trips/tests.py
+++ b/trips/tests.py
@@ -141,7 +141,7 @@ class TripsTestCase(GraphQLTestCase):
                 }
             }
             ''',
-            op_name='Trip'
+            op_name='createTrip'
         )
 
         expected = {
@@ -180,7 +180,7 @@ class TripsTestCase(GraphQLTestCase):
                 }
             }
             ''',
-            op_name='Trip'
+            op_name='createTrip'
         )
 
         expected = {
@@ -192,6 +192,63 @@ class TripsTestCase(GraphQLTestCase):
                         "originAbbrev": "SAI",
                         "originLat": "43.163141",
                         "originLong": "-1.23811"
+                    }
+                }
+            }
+        }
+
+        content = json.loads(response.content)
+
+        self.assertResponseNoErrors(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, expected)
+
+    def test_create_destination(self):
+        response = self.query(
+            '''
+            mutation {
+                createDestination(userApiKey: "1234", tripId: ''' + str(Trip.objects.first().id) + ''', location: "Stockholm, Sweden", startDate: "2020-03-23", endDate: "2020-03-30") {
+                    destination {
+                        location
+                        abbrev
+                        lat
+                        long
+                        tripdestinationSet {
+                            startDate
+                            endDate
+                            trip {
+                                name
+                                origin
+                                originAbbrev
+                            }
+                        }
+                    }
+                }
+            }
+            ''',
+            op_name='createDestination'
+        )
+
+        expected = {
+            "data": {
+                "createDestination": {
+                    "destination": {
+                        "location": "Stockholm, Sweden",
+                        "abbrev": "STO",
+                        "lat": "59.32932349999999",
+                        "long": "18.0685808",
+                        "tripdestinationSet": [
+                            {
+                                "startDate": "2020-03-23",
+                                "endDate": "2020-03-30",
+                                "trip": {
+                                    "name": "Spring Break",
+                                    "origin": "Denver, CO, USA",
+                                    "originAbbrev": "DEN",
+                                }
+                            }
+                        ]
                     }
                 }
             }


### PR DESCRIPTION
### What's this PR do?
- Adds createDestination mutation to add a destination and trip destination to an existing trip
- Tests happy path

### Where should the reviewer start?
- In the tests.py file, then in schema.py to examine the mutation itself

### How should this be manually tested?
- Using localhost

### What are the relevant tickets?
- #35: User can create a destination for a trip