### PR TITLE
User can get a list of Yelp activities for a location

### DIFF
--- a/globe_trotter/urls.py
+++ b/globe_trotter/urls.py
@@ -20,8 +20,10 @@ from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
 
 from globe_trotter.schema import schema
+from yelp_activities.views import yelp_activities
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('graphql/', csrf_exempt(GraphQLView.as_view(graphiql=True, schema=schema))),
+    path('api/v1/yelp_activities/', yelp_activities, name='yelp_activities')
 ]

--- a/trips/admin.py
+++ b/trips/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/trips/views.py
+++ b/trips/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/yelp_activities/apps.py
+++ b/yelp_activities/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class YelpActivitiesConfig(AppConfig):
+    name = 'yelp_activities'

--- a/yelp_activities/tests.py
+++ b/yelp_activities/tests.py
@@ -1,0 +1,21 @@
+import unittest
+import json
+from django.test import Client
+
+class YelpActivitiesTest(unittest.TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_details(self):
+        response = self.client.get('/api/v1/yelp_activities/?lat=41.9027835&long=12.4963655')
+        data = json.loads(response.content)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(data['activities']), 20)
+
+        self.assertTrue(data['activities'][0]['name'])
+        self.assertTrue(data['activities'][0]['address'])
+        self.assertTrue(data['activities'][0]['category'])
+        self.assertTrue(type(data['activities'][0]['rating']) is float)
+        self.assertTrue(type(data['activities'][0]['lat']) is float)
+        self.assertTrue(type(data['activities'][0]['long']) is float)

--- a/yelp_activities/views.py
+++ b/yelp_activities/views.py
@@ -1,0 +1,29 @@
+from django.shortcuts import render
+from django.http import JsonResponse
+import requests
+import environ
+
+env = environ.Env(
+    DEBUG=(bool, False)
+)
+
+def yelp_activities(request):
+    lat = request.GET['lat']
+    long = request.GET['long']
+    headers = {'Authorization': f'Bearer {env("YELP_API_KEY")}'}
+    params = {'latitude': lat, 'longitude': long, 'categories': 'landmarks', 'sort_by': 'rating'}
+    businesses = requests.get('https://api.yelp.com/v3/businesses/search', params=params, headers=headers).json()['businesses']
+
+    formatted_data = {'activities': []}
+    for business in businesses:
+        formatted_data['activities'].append({
+            'name': business['name'],
+            'address': ', '.join(business['location']['display_address']),
+            'category': business['categories'][0]['title'],
+            'rating': business['rating'],
+            'image': business['image_url'],
+            'lat': business['coordinates']['latitude'],
+            'long': business['coordinates']['longitude']
+        })
+
+    return JsonResponse(formatted_data)


### PR DESCRIPTION
### What's this PR do?
- Adds `/api/v1/yelp_activities` endpoint to format Yelp API data
- Adds test for endpoint

### Where should the reviewer start?
- In the yelp_activities app. Start with tests

### How should this be manually tested?
- Using localhost

### Any background context you want to provide?
- Getting a list of activities with lat/long to populate the map of a destination

### What are the relevant tickets?
- #39: User can get a list of Yelp activities for a location