### PR TITLE
User can add an activity to a trip destination #42

### DIFF
--- a/trips/schema.py
+++ b/trips/schema.py
@@ -79,6 +79,29 @@ class CreateDestination(Mutation):
         else:
             return GraphQLError('Invalid location. Please try again.')
 
+class CreateActivity(Mutation):
+    activity = graphene.Field(ActivityType)
+
+    class Arguments:
+        user_api_key = graphene.String(required=True)
+        trip_destination_id = graphene.ID(required=True)
+        name = graphene.String(required=True)
+        date = graphene.types.datetime.Date(required=True)
+        address = graphene.String(required=True)
+        category = graphene.String(required=True)
+        rating = graphene.Float(required=True)
+        image = graphene.String(required=True)
+        lat = graphene.Float(required=True)
+        long = graphene.Float(required=True)
+
+    def mutate(self, info, user_api_key, trip_destination_id, name, date, address, category, rating, image, lat, long):
+        user = User.objects.get(api_key = user_api_key)
+        trip_destination = TripDestination.objects.filter(trip__user_id=user.id).get(id=trip_destination_id)
+        activity = Activity(name=name, date=date, address=address, category=category, rating=rating, image=image, lat=str(lat), long=str(long), trip_destination=trip_destination)
+        activity.save()
+
+        return CreateActivity(activity=activity)
+
 class Query(ObjectType):
     all_trips = graphene.List(TripType, user_api_key=graphene.String(required=True))
 
@@ -90,3 +113,4 @@ class Query(ObjectType):
 class Mutation(ObjectType):
     create_trip = CreateTrip.Field()
     create_destination = CreateDestination.Field()
+    create_activity = CreateActivity.Field()

--- a/trips/tests.py
+++ b/trips/tests.py
@@ -314,3 +314,66 @@ class TripsTestCase(GraphQLTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(content['errors'][0]['message'], 'Invalid location. Please try again.')
+
+    def test_create_activity(self):
+        response = self.query(
+            '''
+            mutation {
+                createActivity(userApiKey: "1234", tripDestinationId: ''' + str(TripDestination.objects.first().id) + ''', name: "Arc de Triomf", date: "2020-03-18", address: "Passeig de Sant Joan, s/n, 08010 Barcelona, Spain", category: "Landmarks & Historical Buildings", rating: 4.0, image: "https://s3-media3.fl.yelpcdn.com/bphoto/bmWXY-0so2VYI_lYv-pbVg/o.jpg", lat: 41.3910646236233, long: 2.1806213137548) {
+                    activity {
+                        name
+                        date
+                        address
+                        category
+                        rating
+                        image
+                        lat
+                        long
+                        tripDestination {
+                            trip {
+                                name
+                            }
+                            destination {
+                                location
+                                abbrev
+                            }
+                        }
+                    }
+                }
+            }
+            ''',
+            op_name='createActivity'
+        )
+
+        expected = {
+            "data": {
+                "createActivity": {
+                    "activity": {
+                        "name": "Arc de Triomf",
+                        "date": "2020-03-18",
+                        "address": "Passeig de Sant Joan, s/n, 08010 Barcelona, Spain",
+                        "category": "Landmarks & Historical Buildings",
+                        "rating": 4,
+                        "image": "https://s3-media3.fl.yelpcdn.com/bphoto/bmWXY-0so2VYI_lYv-pbVg/o.jpg",
+                        "lat": "41.3910646236233",
+                        "long": "2.1806213137548",
+                        "tripDestination": {
+                            "trip": {
+                                "name": "Spring Break"
+                            },
+                            "destination": {
+                                "location": "Barcelona, Spain",
+                                "abbrev": "BCN"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        content = json.loads(response.content)
+
+        self.assertResponseNoErrors(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, expected)


### PR DESCRIPTION
### What's this PR do?
- Add createActivity mutation to schema for activity creation given a tripDestination id and date
- Add happy path test for mutation

### Where should the reviewer start?
- In tests.py, then schema.py to check createActivity mutation

### How should this be manually tested?
- By creating a mutation in localhost/Postman

### What are the relevant tickets?
- #42: User can add an activity to a trip destination

### Questions
- How can we avoid passing in all of the activity information into the mutation?