### PR TITLE
User can delete a trip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Now create, migrate, and seed the development database by executing these comman
 
 ```
 psql
-CREATE DATABASE globe_trotter_api_dev
+CREATE DATABASE globe_trotter_api_dev;
 \q
 python3 manage.py migrate
 python3 manage.py loaddata trips.json
@@ -237,6 +237,100 @@ Response body example:
       }
     }
   }
+}
+```
+
+#### createActivity Mutation
+
+This mutation creates an activity for a destination on an authenticated user's trip given the `tripDestinationId`, `date`, activity information. See the table above for attributes that can be added to the mutation.
+
+Request body example:
+```
+mutation {
+  createActivity(userApiKey: "<USER_API_KEY>", tripDestinationId: 1, name: "Arc de Triomf", date: "2020-03-18", address: "Passeig de Sant Joan, s/n, 08010 Barcelona, Spain", category: "Landmarks & Historical Buildings", rating: 4.0, image: "https://s3-media3.fl.yelpcdn.com/bphoto/bmWXY-0so2VYI_lYv-pbVg/o.jpg", lat: 41.3910646236233, long: 2.1806213137548) {
+    activity {
+      name
+      date
+      address
+      category
+      rating
+      image
+      lat
+      long
+      tripDestination {
+        trip {
+          name
+        }
+        destination {
+          location
+          abbrev
+        }
+      }
+    }
+  }
+}
+```
+
+Response body example:
+```
+{
+  "data": {
+    "createActivity": {
+      "activity": {
+        "name": "Arc de Triomf",
+        "date": "2020-03-18",
+        "address": "Passeig de Sant Joan, s/n, 08010 Barcelona, Spain",
+        "category": "Landmarks & Historical Buildings",
+        "rating": 4,
+        "image": "https://s3-media3.fl.yelpcdn.com/bphoto/bmWXY-0so2VYI_lYv-pbVg/o.jpg",
+        "lat": "41.3910646236233",
+        "long": "2.1806213137548",
+        "tripDestination": {
+          "trip": {
+            "name": "Spring Break"
+          },
+          "destination": {
+            "location": "Barcelona, Spain",
+            "abbrev": "BCN"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### deleteTrip Mutation
+
+This mutation deletes a trip and all resources belonging to that trip  by `tripId` for an authenticated user. All trip attributes except relationships to other tables can be added to the mutation response.
+
+Request body example:
+```
+mutation {
+    deleteTrip (userApiKey: "<USER_API_KEY>", tripId: 5) {
+        id
+        name
+        origin
+        originAbbrev
+        originLat
+        originLong
+    }
+}
+```
+
+Response body example:
+```
+{
+    "data": {
+        "deleteTrip": {
+            "id": "5",
+            "name": "Celebratory Adventure",
+            "origin": "London, UK",
+            "originAbbrev": "LON",
+            "originLat": "51.5073509",
+            "originLong": "-0.1277583"
+        }
+    }
 }
 ```
 

--- a/trips/schema.py
+++ b/trips/schema.py
@@ -102,6 +102,25 @@ class CreateActivity(Mutation):
 
         return CreateActivity(activity=activity)
 
+class DeleteTrip(Mutation):
+    id = graphene.ID()
+    name = graphene.String()
+    origin = graphene.String()
+    origin_abbrev = graphene.String()
+    origin_lat = graphene.String()
+    origin_long = graphene.String()
+
+    class Arguments:
+        user_api_key = graphene.String(required=True)
+        trip_id = graphene.ID(required=True)
+
+    def mutate(self, info, user_api_key, trip_id):
+        user = User.objects.get(api_key = user_api_key)
+        trip = Trip.objects.filter(user_id=user.id).get(id=trip_id)
+        trip.delete()
+
+        return DeleteTrip(id=trip_id, name=trip.name, origin=trip.origin, origin_abbrev=trip.origin_abbrev, origin_lat=trip.origin_lat, origin_long=trip.origin_long)
+
 class Query(ObjectType):
     all_trips = graphene.List(TripType, user_api_key=graphene.String(required=True))
 
@@ -114,3 +133,4 @@ class Mutation(ObjectType):
     create_trip = CreateTrip.Field()
     create_destination = CreateDestination.Field()
     create_activity = CreateActivity.Field()
+    delete_trip = DeleteTrip.Field()

--- a/trips/tests.py
+++ b/trips/tests.py
@@ -377,3 +377,38 @@ class TripsTestCase(GraphQLTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(content, expected)
+
+    def test_delete_trip(self):
+        response = self.query(
+            '''
+            mutation {
+                deleteTrip (userApiKey: "1234", tripId: ''' + str(Trip.objects.first().id) + ''') {
+                    name
+                    origin
+                    originAbbrev
+                    originLat
+                    originLong
+                }
+            }
+            ''',
+            op_name='createActivity'
+        )
+
+        expected = {
+            "data": {
+                "deleteTrip": {
+                    "name": "Spring Break",
+                    "origin": "Denver, CO, USA",
+                    "originAbbrev": "DEN",
+                    "originLat": "39.7392",
+                    "originLong": "104.9903"
+                }
+            }
+        }
+
+        content = json.loads(response.content)
+
+        self.assertResponseNoErrors(response)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, expected)


### PR DESCRIPTION
### What's this PR do?
- Add deleteTrip mutation to schema to delete a trip by ID and all of its nested resources
- Add testing for endpoint
- Update README with documentation for deleteTrip mutation

### Where should the reviewer start?
- Reading the documentation for the endpoint in the README
- Looking at test in tests.py
- Looking at mutation in schema

### How should this be manually tested?
- Using localhost or Postman to delete a trip

### What are the relevant tickets?
- #44: User can delete a trip